### PR TITLE
Use relative path in macroquad_utils, use / as path seperator

### DIFF
--- a/macroquad_utils/src/lib.rs
+++ b/macroquad_utils/src/lib.rs
@@ -14,7 +14,7 @@ pub fn derive_texture_dyn_loader(item: TokenStream) -> TokenStream {
 
             for field in &st.fields {
                 let name = field.ident.as_ref().unwrap();
-                let path = format!("D:/Stuff/Coding/Rust/color_swap/assets/{}.png", name);
+                let path = format!("./assets/{}.png", name);
                 struct_inside.extend(quote! {
                     #name: macroquad::texture::load_texture(#path).await.unwrap(),
                 })
@@ -48,7 +48,7 @@ pub fn derive_texture_static_loader(item: TokenStream) -> TokenStream {
 
             for field in &st.fields {
                 let name = field.ident.as_ref().unwrap();
-                let path = format!("D:/Stuff/Coding/Rust/color_swap/assets/{}.png", name);
+                let path = format!("./assets/{}.png", name);
                 struct_inside.extend(quote! {
                     #name: macroquad::texture::Texture2D::from_file_with_format( include_bytes!(path), None),
                 })

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -50,7 +50,7 @@ impl Textures {
 
 impl Assets {
     pub async fn default() -> Self {
-        let font = load_ttf_font_from_bytes( include_bytes!("..\\assets\\FatPixelFont.ttf") );
+        let font = load_ttf_font_from_bytes( include_bytes!("../assets/FatPixelFont.ttf") );
         if font.is_err() {
             error!("Unable to load monogram font!")
         }
@@ -58,12 +58,12 @@ impl Assets {
         return Assets {
             font_monogram: font.unwrap(),
             t: Textures::new().await,
-            play_song: load_sound_from_bytes( include_bytes!("..\\assets\\medium_boss.wav") ).await.unwrap(),
-            menu_song: load_sound_from_bytes( include_bytes!("..\\assets\\little_slime.wav") ).await.unwrap(),
-            menu_switch: load_sound_from_bytes( include_bytes!("..\\assets\\menu.wav") ).await.unwrap(),
-            shoot: load_sound_from_bytes( include_bytes!("..\\assets\\shoot.wav") ).await.unwrap(),
-            hit: load_sound_from_bytes( include_bytes!("..\\assets\\hit.wav") ).await.unwrap(),
-            dead: load_sound_from_bytes( include_bytes!("..\\assets\\dead.wav") ).await.unwrap(),
+            play_song: load_sound_from_bytes( include_bytes!("../assets/medium_boss.wav") ).await.unwrap(),
+            menu_song: load_sound_from_bytes( include_bytes!("../assets/little_slime.wav") ).await.unwrap(),
+            menu_switch: load_sound_from_bytes( include_bytes!("../assets/menu.wav") ).await.unwrap(),
+            shoot: load_sound_from_bytes( include_bytes!("../assets/shoot.wav") ).await.unwrap(),
+            hit: load_sound_from_bytes( include_bytes!("../assets/hit.wav") ).await.unwrap(),
+            dead: load_sound_from_bytes( include_bytes!("../assets/dead.wav") ).await.unwrap(),
         }
     }
 }


### PR DESCRIPTION
`/` seems to work on windows as well (tested it separately on my windows machine, maybe it works for you too?) and is required for unix, which is why I had to change it originally.
Also had to change the absolute paths in `macroquad_utils` to relative ones to compile it.

Really fun game, got me hooked for quite some time :)

 